### PR TITLE
corrected negative waitgroup counter bug

### DIFF
--- a/session.go
+++ b/session.go
@@ -173,6 +173,8 @@ func (s *Session) Close() error {
 		for _, i := range s.interests {
 			i(nil, s.connErr)
 		}
+		// delete all interests
+		s.interests = make(map[cid.Cid]func([]byte, error))
 	}
 	return nil
 }


### PR DESCRIPTION
```go
	s.on(c, func(rb []byte, re error) {
		data = rb
		err = re
		wg.Done()
	})

```

gets executed twice, resulting in negative WaitGroup counter. This is fixed by removing the func (cb) from `s.interests` upon `connErr`.